### PR TITLE
Add support for OCaml 5.5

### DIFF
--- a/src/secp256k1.ml
+++ b/src/secp256k1.ml
@@ -58,8 +58,8 @@ module Context = struct
 end
 
 module Key = struct
-  type secret
-  type public
+  type secret = private [`Secret]
+  type public = private [`Public]
   type _ t =
     | Sk : buffer -> secret t
     | Pk : buffer -> public t
@@ -255,8 +255,8 @@ module Key = struct
 end
 
 module Sign = struct
-  type plain
-  type recoverable
+  type plain = private [`Plain]
+  type recoverable = private [`Recoverable]
   type _ t =
     | P : buffer -> plain t
     | R : buffer -> recoverable t


### PR DESCRIPTION
This adds support for the upcoming OCaml release.
The reason for this change is detailed in https://github.com/ocaml/ocaml/issues/14224